### PR TITLE
Allow user to pass lat/lon in the url

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1,5 +1,12 @@
 $(document).ready(function() {
-	getLocation(); 
+	var lat = GetURLParameter('lat');
+	var lon = GetURLParameter('lon');
+
+	if (lat && lon) {
+		showPosition({coords: {latitude: lat, longitude: lon}});
+	} else {
+		getLocation();
+	}
 });
 
 function getWeather(link) {
@@ -62,3 +69,13 @@ function showPosition(position) {
     getWeather(url);
     $("#browser_geo").text("wow, located!").css("cursor", "auto").css("color", "#FF5CFF");
 }
+function GetURLParameter(sParam) {
+  var sPageURL = window.location.search.substring(1);
+  var sURLVariables = sPageURL.split('&');
+  for (var i = 0; i < sURLVariables.length; i++) {
+    var sParameterName = sURLVariables[i].split('=');
+    if (sParameterName[0] == sParam) {
+      return sParameterName[1];
+    }
+  }
+}​


### PR DESCRIPTION
This PR allows the user to directly pass a latitude and longitude via the URL.
For example: `http://dogeweather.com/?lat=XXX&lon=YYY`

The current use case is where the DNS router is actually geolocating us miles away from our location.

This could be useful if you want to see the weather in another location as well.